### PR TITLE
Update conversion error in convert function

### DIFF
--- a/typepy/type/_base.py
+++ b/typepy/type/_base.py
@@ -115,7 +115,7 @@ class AbstractType(TypeCheckerInterface, ValueConverterInterface):
             return self.force_convert()
 
         raise TypeConversionError(
-            "failed to convert from {} to {}".format(type(self._data).__name__, self.typename)
+            "failed to convert {} from {} to {}".format(self._data, type(self._data).__name__, self.typename)
         )
 
     def force_convert(self):


### PR DESCRIPTION
Changed the error from `AbstractType.convert()` a little to be more descriptive. When you have hundreds of objects to convert, it makes life easier for me by raising the error with the value of the object that it failed to convert. For example,
Instead of:

    ValueError: failed to convert from str to DATETIME

It would raise:

    ValueError: failed to convert 2021-02-10T99:59:00+0800 from str to DATETIME

Now I know exactly what needs to be fixed.