### PR TITLE
Replace pytz with ZoneInfo + misc datetime fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -101,7 +101,6 @@ Optional dependencies
 These packages can be installed via ``pip install typepy[datetime]``:
 
 - `python-dateutil <https://dateutil.readthedocs.io/en/stable/>`__
-- `pytz <https://pypi.org/project/pytz/>`__
 
 Usage
 =======

--- a/docs/pages/introduction/installation.rst
+++ b/docs/pages/introduction/installation.rst
@@ -38,4 +38,3 @@ Optional dependencies
 These packages can be installed via ``pip install typepy[datetime]``:
 
 - `python-dateutil <https://dateutil.readthedocs.io/en/stable/>`__
-- `pytz <https://pypi.org/project/pytz/>`__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ known_third_party = [
   'logbook',
   'pytablewriter',
   'pytest',
-  'pytz',
   'sphinx_rtd_theme',
   'tcolorpy',
 ]

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ with open(os.path.join(REQUIREMENT_DIR, "test_requirements.txt")) as f:
 DATETIME_REQUIRES = [
     "python-dateutil>=2.8.0,<3.0.0",
     "packaging",
+    'tzdata; sys_platform == "win32"',
 ]
 
 setuptools.setup(

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,6 @@ with open(os.path.join(REQUIREMENT_DIR, "test_requirements.txt")) as f:
 
 DATETIME_REQUIRES = [
     "python-dateutil>=2.8.0,<3.0.0",
-    "pytz>=2018.9",
     "packaging",
 ]
 

--- a/test/test_type.py
+++ b/test/test_type.py
@@ -8,7 +8,7 @@ from decimal import Decimal
 from ipaddress import IPv4Address, IPv6Address
 
 import pytest
-from pytz import timezone, utc
+from zoneinfo import ZoneInfo
 
 import typepy
 from typepy import StrictLevel
@@ -47,27 +47,27 @@ class Test_DateTime:
     @pytest.mark.parametrize(
         ["value", "timezone", "expected"],
         [
-            [datetime(2017, 1, 29, 10, 27, 3), utc, datetime(2017, 1, 29, 10, 27, 3)],
+            [datetime(2017, 1, 29, 10, 27, 3), ZoneInfo("UTC"), datetime(2017, 1, 29, 10, 27, 3)],
             [
                 datetime(2017, 1, 29, 10, 27, 3),
-                timezone("Asia/Tokyo"),
+                ZoneInfo("Asia/Tokyo"),
                 datetime(2017, 1, 29, 10, 27, 3),
             ],
-            ["2017-01-29 19:27:03", utc, datetime(2017, 1, 29, 19, 27, 3)],
-            ["2017-01-29 19:27:03", timezone("Asia/Tokyo"), datetime(2017, 1, 29, 19, 27, 3)],
-            [1485685623, utc, datetime(2017, 1, 29, 10, 27, 3)],
-            [1485685623, timezone("Asia/Tokyo"), datetime(2017, 1, 29, 19, 27, 3)],
+            ["2017-01-29 19:27:03", ZoneInfo("UTC"), datetime(2017, 1, 29, 19, 27, 3)],
+            ["2017-01-29 19:27:03", ZoneInfo("Asia/Tokyo"), datetime(2017, 1, 29, 19, 27, 3)],
+            [1485685623, ZoneInfo("UTC"), datetime(2017, 1, 29, 10, 27, 3)],
+            [1485685623, ZoneInfo("Asia/Tokyo"), datetime(2017, 1, 29, 19, 27, 3)],
         ],
     )
     def test_normal_datetime_timezone(self, value, timezone, expected):
         result = typepy.DateTime(value, strict_level=StrictLevel.MIN, timezone=timezone).convert()
 
-        assert result == timezone.localize(expected)
+        assert result == expected.replace(tzinfo=timezone)
 
     def test_normal_datetime_tz_aware(self):
-        utc_dt = datetime(2017, 1, 29, 10, 27, 3, tzinfo=utc)
+        utc_dt = datetime(2017, 1, 29, 10, 27, 3, tzinfo=ZoneInfo("UTC"))
         got = typepy.DateTime(
-            utc_dt, strict_level=StrictLevel.MIN, timezone=timezone("Asia/Tokyo")
+            utc_dt, strict_level=StrictLevel.MIN, timezone=ZoneInfo("Asia/Tokyo")
         ).convert()
         assert got.tzinfo.tzname(got) == "JST"
 
@@ -76,8 +76,18 @@ class Test_DateTime:
             strict_level=StrictLevel.MIN,
         ).convert()
         assert jst_dt.tzinfo.utcoffset(jst_dt) == timedelta(seconds=32400)
-        got = typepy.DateTime(jst_dt, strict_level=StrictLevel.MIN, timezone=utc).convert()
+        got = typepy.DateTime(jst_dt, strict_level=StrictLevel.MIN, timezone=ZoneInfo("UTC")).convert()
         assert got.tzinfo.utcoffset(got) == timedelta(0)
+
+    def test_normal_datetime_dst_ambiguous_default_fold(self):
+        # 2024-11-03 01:30 in US/Eastern is ambiguous (fall-back).
+        # Per PEP 495, fold defaults to 0 — the earlier occurrence (EDT, UTC-4).
+        ambiguous = datetime(2024, 11, 3, 1, 30)
+        got = typepy.DateTime(
+            ambiguous, strict_level=StrictLevel.MIN, timezone=ZoneInfo("US/Eastern")
+        ).convert()
+        assert got.tzinfo.utcoffset(got) == timedelta(hours=-4)
+        assert got.tzinfo.tzname(got) == "EDT"
 
     @pytest.mark.parametrize(
         ["value", "expected"],

--- a/test/test_type.py
+++ b/test/test_type.py
@@ -76,7 +76,9 @@ class Test_DateTime:
             strict_level=StrictLevel.MIN,
         ).convert()
         assert jst_dt.tzinfo.utcoffset(jst_dt) == timedelta(seconds=32400)
-        got = typepy.DateTime(jst_dt, strict_level=StrictLevel.MIN, timezone=ZoneInfo("UTC")).convert()
+        got = typepy.DateTime(
+            jst_dt, strict_level=StrictLevel.MIN, timezone=ZoneInfo("UTC")
+        ).convert()
         assert got.tzinfo.utcoffset(got) == timedelta(0)
 
     def test_normal_datetime_dst_ambiguous_default_fold(self):

--- a/tox.ini
+++ b/tox.ini
@@ -75,7 +75,6 @@ deps =
     mypy>=1
     ruff>=0.8
     types-python-dateutil
-    types-pytz
 commands =
     codespell typepy docs/pages test -q2 --check-filenames
     mypy typepy setup.py

--- a/typepy/converter/_datetime.py
+++ b/typepy/converter/_datetime.py
@@ -11,8 +11,6 @@ from ._interface import AbstractValueConverter
 
 
 class DateTimeConverter(AbstractValueConverter):
-    __DAYS_TO_SECONDS_COEF = 60**2 * 24
-    __MICROSECONDS_TO_SECONDS_COEF = 1000**2
     __COMMON_DST_TIMEZONE_TABLE = {
         -36000: "America/Adak",  # -1000
         -32400: "US/Alaska",  # -0900
@@ -56,7 +54,7 @@ class DateTimeConverter(AbstractValueConverter):
 
         if self.__timezone:
             if self.__datetime.tzinfo is None:
-                self.__datetime = self.__timezone.localize(self.__datetime)
+                self.__datetime = self.__datetime.replace(tzinfo=self.__timezone)
             else:
                 self.__datetime = datetime.fromtimestamp(
                     self.__datetime.timestamp(), tz=self.__timezone
@@ -68,35 +66,24 @@ class DateTimeConverter(AbstractValueConverter):
         from ..type._integer import Integer
         from ..type._realnumber import RealNumber
 
-        conv_error = TypeConversionError(
-            "timestamp is out of the range of values supported by the platform"
-        )
-
         timestamp = Integer(self._value, strict_level=1).try_convert()
-        if timestamp:
-            try:
-                self.__datetime = datetime.fromtimestamp(timestamp, self.__timezone)
-            except (ValueError, OSError, OverflowError):
-                raise conv_error
+        if timestamp is None:
+            timestamp = RealNumber(self._value, strict_level=1).try_convert()
+        if timestamp is None:
+            return None
 
-            return self.__datetime
+        try:
+            self.__datetime = datetime.fromtimestamp(float(timestamp), self.__timezone)
+        except (ValueError, OSError, OverflowError):
+            raise TypeConversionError(
+                "timestamp is out of the range of values supported by the platform"
+            )
 
-        timestamp = RealNumber(self._value, strict_level=1).try_convert()
-        if timestamp:
-            try:
-                self.__datetime = datetime.fromtimestamp(int(timestamp), self.__timezone).replace(
-                    microsecond=int((timestamp - int(timestamp)) * 1000000)
-                )
-            except (ValueError, OSError, OverflowError):
-                raise conv_error
-
-            return self.__datetime
-
-        return None
+        return self.__datetime
 
     def __from_datetime_string(self):
         import dateutil.parser
-        import pytz
+        from zoneinfo import ZoneInfo
 
         self.__validate_datetime_string()
 
@@ -113,28 +100,21 @@ class DateTimeConverter(AbstractValueConverter):
             raise TypeConversionError(f"failed to parse as a datetime: type={type(self._value)}")
 
         if self.__timezone:
-            pytz_timezone = self.__timezone
+            tz = self.__timezone
         else:
             try:
                 dst_timezone_name = self.__get_dst_timezone_name(self.__get_timedelta_sec())
             except (AttributeError, KeyError):
                 return self.__datetime
 
-            pytz_timezone = pytz.timezone(dst_timezone_name)
+            tz = ZoneInfo(dst_timezone_name)
 
-        self.__datetime = self.__datetime.replace(tzinfo=None)
-        self.__datetime = pytz_timezone.localize(self.__datetime)
+        self.__datetime = self.__datetime.replace(tzinfo=tz)
 
         return self.__datetime
 
     def __get_timedelta_sec(self):
-        dt = self.__datetime.utcoffset()
-
-        return int(
-            dt.days * self.__DAYS_TO_SECONDS_COEF
-            + float(dt.seconds)
-            + dt.microseconds / self.__MICROSECONDS_TO_SECONDS_COEF
-        )
+        return int(self.__datetime.utcoffset().total_seconds())
 
     def __get_dst_timezone_name(self, offset):
         return self.__COMMON_DST_TIMEZONE_TABLE[offset]


### PR DESCRIPTION
Hi!

Big one is using `zoneinfo.ZoneInfo` in place of `pytz` since this library is 3.9+. Mostly just `.localize` to `.replace` but I added a test for the [PEP 495](https://peps.python.org/pep-0495/) / default `fold=0` behaviour. Technically this is a behaviour change since `pytz` defaults to `is_dst=False` but this would align more consistently with the current stdlib semantics / PEP 495. See `test_normal_datetime_dst_ambiguous_default_fold`

Smaller fixes:

Simplified `__from_timestamp`; `datetime.fromtimestamp()` accepts a float (and preserves microseconds) so we test `Integer`/`RealNumber` against `timestamp` and then a single `fromtimestamp(float(...))` call. (Adjusted the guards to `is not None` since technically 0 / 0.0 are valid timestamps :shrug:)

Simplified `__get_timedelta_sec`: Just use the `timedelta.total_seconds()`. No behaviour change.